### PR TITLE
Keeping mime-type and filename of original file

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -193,7 +193,7 @@ if ($requestMethod === "PUT" || $requestMethod === "PATCH") {
             $filePath = realpath($file['tmp_name']);
 
             if (CURLFILE) {
-                $data[$fileName] = new CURLFile($filePath);
+                $data[$fileName] = new CURLFile($filePath, $file['type'], $file['name']);
             } else {
                 $data[$fileName] = '@' . $filePath;
             }

--- a/proxy.php
+++ b/proxy.php
@@ -281,7 +281,7 @@ foreach ($responseHeaders as $header) {
 
 if ($debug) {
     echo 'Headers sent to proxy' . PHP_EOL . PHP_EOL;
-    echo implode($httpHeadersAll, PHP_EOL);
+    echo implode(PHP_EOL, $httpHeadersAll);
     echo HR;
 
     echo '$_GET sent to proxy' . PHP_EOL . PHP_EOL;
@@ -293,15 +293,15 @@ if ($debug) {
     echo HR;
 
     echo 'Headers sent to target' . PHP_EOL . PHP_EOL;
-    echo implode($requestHeaders, PHP_EOL);
+    echo implode(PHP_EOL, $requestHeaders);
     echo HR;
 
     echo 'Headers received from target' . PHP_EOL . PHP_EOL;
-    echo implode($responseHeaders, PHP_EOL);
+    echo implode(PHP_EOL, $responseHeaders);
     echo HR;
 
     echo 'Headers sent from proxy to client' . PHP_EOL . PHP_EOL;
-    echo implode(headers_list(), PHP_EOL);
+    echo implode(PHP_EOL, headers_list());
     echo HR;
 
     echo 'Body sent from proxy to client' . PHP_EOL . PHP_EOL;


### PR DESCRIPTION
### The scenario

If I add a POST file like the following:
```
$data['test_file'] = curl_file_create('/tmp/user_photo.jpeg', 'image/jpeg');
```
Then `print_r($_FILES)` in proxy script will show the file as:
```
[test_file] => Array ( 
    [name] => user_photo.jpeg 
    [type] => image/jpeg 
    [tmp_name] => /tmp/system/dir/phpTmpName
    [error] => 0 
    [size] => 2046175 
)
```

But, when forwarded to target url, we are receiving the file as:
```
Array ( 
    [name] => phpTmpName 
    [type] => application/octet-stream
    [tmp_name] => /tmp/system/dir/phpAnotherTmpName
    [error] => 0 
    [size] => 2046175 
)
```
So, the mime-type is always changing to `application/octet-stream` and  original name and extension is being lost.
Many APIs and services verifies submitted files using mime-type and/or extension - where it may become a vital issue.

### The solution
Why is this happening? Because the proxy script is using the temporary uploaded file as source file, where there is no extension.
We can solve it just by setting the type and original name in initiating `CURLFile`.

**Additional Change:** Swapped the position of glue in some `implode()` to avoid depreciation error in PHP 7.4. 