### PR TITLE
Disable HTTP Expect

### DIFF
--- a/Proxy.php
+++ b/Proxy.php
@@ -213,6 +213,7 @@ class Proxy
 
             $results[] = "$headerLine";
         }
+        $results[] = "Expect:";
 
         return $results;
     }


### PR DESCRIPTION
Without this, cURL will send `Expect: 100-continue` on POST/PUT requests which will make the proxy fail. See https://gms.tf/when-curl-sends-100-continue.html